### PR TITLE
fix(middleware): Main include file includes all main middleware components.

### DIFF
--- a/lib/rack/service_api_versioning.rb
+++ b/lib/rack/service_api_versioning.rb
@@ -2,6 +2,7 @@
 
 require 'rack/service_api_versioning/version'
 require 'rack/service_api_versioning/accept_content_type_selector'
+require 'rack/service_api_versioning/api_version_redirector'
 require 'rack/service_api_versioning/service_component_describer'
 
 # All(?) Rack code is namespaced within this module.

--- a/test/rack/service_api_versioning/integration/all_middleware_included_test.rb
+++ b/test/rack/service_api_versioning/integration/all_middleware_included_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'rack/service_api_versioning'
+
+describe 'ServiceApiVersioning middleware has' do
+  it 'an AcceptContentTypeSelector class' do
+    actual = Rack::ServiceApiVersioning::AcceptContentTypeSelector
+    expect(actual).must_be_instance_of Class
+  end
+
+  it 'an ApiVersionRedirector class' do
+    actual = ApiVersionRedirector # NOTE: Issue #5
+    expect(actual).must_be_instance_of Class
+  end
+
+  it 'a ServiceComponentDescriber class' do
+    actual = Rack::ServiceApiVersioning::ServiceComponentDescriber
+    expect(actual).must_be_instance_of Class
+  end
+end # describe 'ServiceApiVersioning middleware has'


### PR DESCRIPTION
Previously, `api_version_redirector` had been inadvertently omitted.

When addressing Issue #5, note that the new “integration” test here references the `ApiVersionRedirector` class without namespacing, and will need to be fixed at that time.

[Closes #8]