### PR TITLE
fix(middleware): ACTS encodes correct content type

### DIFF
--- a/test/rack/service_api_versioning/accept_content_type_selector_test.rb
+++ b/test/rack/service_api_versioning/accept_content_type_selector_test.rb
@@ -108,9 +108,14 @@ describe 'Rack::ServiceApiVersioning::AcceptContentTypeSelector' do
             'application/vnd.acme.apidemo.v2+json'
           end
 
-          it 'matches the requested content type/API Version' do
+          it 'matches the correct Service Base URL' do
             expected = SINGLE_API.dig(:api_versions, 'v2', :base_url)
             expect(api_version_data[:base_url]).must_equal expected
+          end
+
+          it 'has the correct Content Type' do
+            expected = SINGLE_API.dig(:api_versions, 'v2', :content_type)
+            expect(api_version_data[:content_type]).must_equal expected
           end
         end # describe 'is an exact match for the available version'
 


### PR DESCRIPTION
Previously, the Content Type string returned from `AcceptContentTypeSelector` would not indicate that the content was JSON-encoded even though the input data (in `env[“'COMPONENT_DESCRIPTION”]`) *did.* This was due to the way the Content Type string was being reconstructed, now fixed.

42 tests, 42 assertions, 0 failures, 0 errors, 0 skips
Coverage: 477 / 477 LOC (100.0%) covered.
RuboCop: 23 files inspected, no offenses detected
Flog: total 295.1, method average 3.3, max 6.3 (Rack::ServiceApiVersioning::EncodedApiVersionData#version_data)
RubyCritic score: 97.06%