### PR TITLE
fix(middleware): Consistently namespace middleware

### DIFF
--- a/lib/rack/service_api_versioning/api_version_redirector.rb
+++ b/lib/rack/service_api_versioning/api_version_redirector.rb
@@ -7,64 +7,71 @@ require_relative './env_items'
 require_relative './list_methods_in_module'
 require_relative './rack_env_for_uri'
 
-# Returns an HTTP 302 response with cleaned-up environment and Location header.
-class ApiVersionRedirector
-  def initialize(app)
-    @app = app
-    @env = nil
-    self
-  end
+# All(?) Rack code is namespaced within this module.
+module Rack
+  # Module includes our middleware components for managing service API versions.
+  module ServiceApiVersioning
+    # Returns an HTTP 302 response with cleaned-up environment and `Location`
+    # header.
+    class ApiVersionRedirector
+      def initialize(app)
+        @app = app
+        @env = nil
+        self
+      end
 
-  def call(env)
-    @env = env
-    response
-  end
+      def call(env)
+        @env = env
+        response
+      end
 
-  private
+      private
 
-  DEFAULT_STATUS = 307
-  private_constant :DEFAULT_STATUS
+      DEFAULT_STATUS = 307
+      private_constant :DEFAULT_STATUS
 
-  attr_reader :app, :env
+      attr_reader :app, :env
 
-  def api_version_base_uri
-    URI.parse(api_version_data[:base_url])
-  end
+      def api_version_base_uri
+        URI.parse(api_version_data[:base_url])
+      end
 
-  def api_version
-    api_version_data[:api_version]
-  end
+      def api_version
+        api_version_data[:api_version]
+      end
 
-  def api_version_data
-    JSON.parse(env['COMPONENT_API_VERSION_DATA'], symbolize_names: true)
-  end
+      def api_version_data
+        JSON.parse(env['COMPONENT_API_VERSION_DATA'], symbolize_names: true)
+      end
 
-  def headers
-    { 'API-Version' => api_version,
-      'Location' => location_header }
-  end
+      def headers
+        { 'API-Version' => api_version,
+          'Location' => location_header }
+      end
 
-  def location_header
-    uri = api_version_base_uri
-    url_from_tweaked_env(uri)
-  end
+      def location_header
+        uri = api_version_base_uri
+        url_from_tweaked_env(uri)
+      end
 
-  def response
-    Rack::Response.new(response_body, DEFAULT_STATUS, headers).finish
-  end
+      def response
+        Rack::Response.new(response_body, DEFAULT_STATUS, headers).finish
+      end
 
-  def response_body
-    '<p>Please resend the request to ' \
-    "<a href='#{location_header}'>this endpoint</a> without caching it.</p>"
-  end
+      def response_body
+        '<p>Please resend the request to ' \
+        "<a href='#{location_header}'>this endpoint</a> without caching it.</p>"
+      end
 
-  def tweak_env_for(uri)
-    @env.merge! RackEnvForUri.call(uri)
-  end
+      def tweak_env_for(uri)
+        @env.merge! RackEnvForUri.call(uri)
+      end
 
-  def url_from_tweaked_env(uri)
-    actual_env = tweak_env_for(uri)
-    req = Rack::Request.new(actual_env)
-    req.url
+      def url_from_tweaked_env(uri)
+        actual_env = tweak_env_for(uri)
+        req = Rack::Request.new(actual_env)
+        req.url
+      end
+    end # class Rack::ServiceApiVersioning::ApiVersionRedirector
   end
 end

--- a/test/rack/service_api_versioning/api_version_redirector_test.rb
+++ b/test/rack/service_api_versioning/api_version_redirector_test.rb
@@ -5,8 +5,8 @@ require 'json'
 
 require 'rack/service_api_versioning/api_version_redirector'
 
-describe 'ApiVersionRedirector' do
-  let(:described_class) { ApiVersionRedirector }
+describe 'Rack::ServiceApiVersioning::ApiVersionRedirector' do
+  let(:described_class) { Rack::ServiceApiVersioning::ApiVersionRedirector }
   let(:app) do
     Class.new do
       def initialize

--- a/test/rack/service_api_versioning/integration/all_middleware_included_test.rb
+++ b/test/rack/service_api_versioning/integration/all_middleware_included_test.rb
@@ -11,7 +11,7 @@ describe 'ServiceApiVersioning middleware has' do
   end
 
   it 'an ApiVersionRedirector class' do
-    actual = ApiVersionRedirector # NOTE: Issue #5
+    actual = Rack::ServiceApiVersioning::ApiVersionRedirector
     expect(actual).must_be_instance_of Class
   end
 


### PR DESCRIPTION
The `ApiVersionRedirector` class was not previously included in the `Rack::ServiceApiVersioning` module as were the other two middleware components.

[Closes #5]
[References #6]
[References Commit 7ac549df]
[References PR #9]

42 tests, 42 assertions, 0 failures, 0 errors, 0 skips
Coverage: 479 / 479 LOC (100.0%) covered.
RuboCop: 23 files inspected, no offenses detected
Flog: total 295.1, method average 3.3, max 6.3 (Rack::ServiceApiVersioning::EncodedApiVersionData#version_data)
RubyCritic score: 97.06%